### PR TITLE
checkIntervalが-1で毎回ルーティング設定がロードされる問題に対応しました

### DIFF
--- a/src/main/java/net/unit8/sastruts/AdvancedRoutingFilter.java
+++ b/src/main/java/net/unit8/sastruts/AdvancedRoutingFilter.java
@@ -75,7 +75,10 @@ public class AdvancedRoutingFilter implements Filter {
 	}
 
 	private void reloadRoutes() {
-		if ((lastLoaded < 0 || System.currentTimeMillis() > lastLoaded + checkInterval * 1000 ) && !loading) {
+		if (loading) {
+			return;
+		}
+		if (lastLoaded < 0 || checkInterval >= 0 && System.currentTimeMillis() > lastLoaded + checkInterval * 1000) {
 			synchronized(this) {
 				if (!loading)
 					loading = true;


### PR DESCRIPTION
checkIntervalが-1で毎回ルーティング設定がロードされる問題に対応しました

checkIntervalに-1にするとリクエスト毎にルーティング設定がロードされてしまいます。

```
System.currentTimeMillis() > lastLoaded + checkInterval * 1000
```

上記の条件だけだとcheckIntervalが負の場合、常に現在時刻の方が大きくなってしまいます。

以上よろしくお願いします。
