### PR TITLE
ルートパッケージがjar内に存在する場合NullPointer例外が発生する問題を修正しました。

### DIFF
--- a/src/main/java/net/unit8/sastruts/routing/detector/ClassControllerDetector.java
+++ b/src/main/java/net/unit8/sastruts/routing/detector/ClassControllerDetector.java
@@ -1,43 +1,57 @@
 package net.unit8.sastruts.routing.detector;
 
-import java.io.File;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 import net.unit8.sastruts.ControllerUtil;
 import net.unit8.sastruts.routing.ControllerDetector;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.seasar.framework.container.S2Container;
 import org.seasar.framework.container.factory.SingletonS2ContainerFactory;
 import org.seasar.framework.convention.NamingConvention;
-import org.seasar.framework.util.ResourceUtil;
+import org.seasar.framework.util.ClassTraversal.ClassHandler;
+import org.seasar.framework.util.ResourcesUtil;
+import org.seasar.framework.util.ResourcesUtil.Resources;
 import org.seasar.framework.util.StringUtil;
 
+/**
+ * HotDeploy/WarmDeploy時用のControllerDetectorです。
+ * 
+ * @author kawasima
+ * @author growthfield
+ *
+ */
 public class ClassControllerDetector implements ControllerDetector {
-	private static final String[] EXTENSIONS = {"class"};
+	/**
+	 * @see ControllerDetector#detect()
+	 */
 	public List<String> detect() {
-		List<String> controllers = new ArrayList<String>();
-
+		final List<String> controllers = new ArrayList<String>();
 		S2Container container = SingletonS2ContainerFactory.getContainer();
 		NamingConvention namingConvention = (NamingConvention)container.getComponent(NamingConvention.class);
-
-		String actionSuffix = namingConvention.getActionSuffix();
-		String actionSubPackageName = namingConvention.fromSuffixToPackageName(actionSuffix);
+		final String actionSuffix = namingConvention.getActionSuffix();
+		final String actionSubPackageName = namingConvention.fromSuffixToPackageName(actionSuffix);
 		for (String rootPackageName : namingConvention.getRootPackageNames()) {
-			String actionClasspath = StringUtil.replace(rootPackageName, ".", "/").concat("/").concat(actionSubPackageName);
-			File dir = ResourceUtil.getResourceAsFile(actionClasspath);
-			Iterator<File> actionIter = FileUtils.iterateFiles(dir, EXTENSIONS, true);
-			while(actionIter.hasNext()) {
-				String relativePath = StringUtils.substring(actionIter.next().getPath(), dir.getPath().length() + 1).replace(File.separatorChar, '/');
-				String path = ControllerUtil.fromClassNameToPath(StringUtil.trimSuffix(relativePath, actionSuffix + ".class"));
-				controllers.add(path);
+			final String actionPackageName = rootPackageName.concat(".").concat(actionSubPackageName);
+			ClassHandler handler = new ClassHandler() {
+				public void processClass(String packageName, String shortClassName) {
+					String pkgPath = StringUtils.removeStart(packageName, actionPackageName);
+					String uncapitalizedShortClassName = ControllerUtil.fromClassNameToPath(shortClassName);
+					String actionPath = StringUtil.trimSuffix(uncapitalizedShortClassName, actionSuffix);
+					StringBuilder sb = new StringBuilder();
+					if (!StringUtils.isEmpty(pkgPath)) {
+						sb.append(pkgPath.substring(1)).append("/");
+					}
+					sb.append(actionPath);
+					controllers.add(sb.toString());
+				}
+			};
+			Resources[] types = ResourcesUtil.getResourcesTypes(actionPackageName);
+			for (Resources r : types) {
+				r.forEach(handler);
 			}
 		}
-
 		return controllers;
 	}
-
 }

--- a/src/main/resources/META-INF/ar.tld
+++ b/src/main/resources/META-INF/ar.tld
@@ -3,6 +3,8 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee web-jsptaglibrary_2_0.xsd" version="2.0">
 	<tlib-version>2.0</tlib-version>
+	<short-name>ar</short-name>
+	<uri>http://ar.sastruts.unit8.net</uri>
 	<function>
 		<name>urlFor</name>
 		<function-class>net.unit8.sastruts.UrlRewriter</function-class>

--- a/src/main/resources/META-INF/ar.tld
+++ b/src/main/resources/META-INF/ar.tld
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tablib xmlns="http://java.sun.com/xml/ns/j2ee"
+<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee web-jsptaglibrary_2_0.xsd" version="2.0">
 	<tlib-version>2.0</tlib-version>
@@ -8,4 +8,4 @@
 		<function-class>net.unit8.sastruts.UrlRewriter</function-class>
 		<function-signature>java.lang.String urlFor(java.lang.String)</function-signature>
 	</function>
-</tablib>
+</taglib>


### PR DESCRIPTION
HotDeploy/WarmDeploy時に使用するClassControllerDetectorですが、Actionパッケージがファイルシステム上に直接存在する前提となっていました。

例えばルートパッケージが複数存在していおり基本のルートパッケージがWEB-INF/classesにあって、共通系のルートパッケージがWEB-INF/lib/common.jarに入っているケースなど、common.jar内のActionパッケージのディレクトリをそのままFileオブジェクトで扱おうとしてNullPointer例外が発生します。

修正としてはseasarが使用しているorg.seasar.framework.util.ResourcesUtil.ResourcesUtilを利用してファイルシステム直/jarファイルに関わらず読めるように対応しました。
