### PR TITLE
Actionのサブパッケージが2階層以上の場合にNoRouteExceptionが発生する問題に対応。

### DIFF
--- a/src/main/java/net/unit8/sastruts/routing/detector/ClassControllerDetector.java
+++ b/src/main/java/net/unit8/sastruts/routing/detector/ClassControllerDetector.java
@@ -41,7 +41,7 @@ public class ClassControllerDetector implements ControllerDetector {
 					String actionPath = StringUtil.trimSuffix(uncapitalizedShortClassName, actionSuffix);
 					StringBuilder sb = new StringBuilder();
 					if (StringUtil.isNotEmpty(pkgPath)) {
-						sb.append(pkgPath.substring(1)).append("/");
+						sb.append(StringUtil.replace(pkgPath.substring(1), ".", "/")).append("/");
 					}
 					sb.append(actionPath);
 					controllers.add(sb.toString());

--- a/src/test/java/net/unit8/sastruts/routing/PathMatchingTest.java
+++ b/src/test/java/net/unit8/sastruts/routing/PathMatchingTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.seasar.framework.unit.Seasar2;
 import org.seasar.framework.unit.annotation.RegisterNamingConvention;
+import org.seasar.framework.unit.annotation.WarmDeploy;
 import org.seasar.framework.util.ResourceUtil;
 
 @RunWith(Seasar2.class)
@@ -38,5 +39,12 @@ public class PathMatchingTest {
 		assertThat(options.getString("section"), is("some/section"));
 		assertThat(options.getString("title"), is("last-words-a-memoir"));
 	}
+
+    @Test
+    public void nestedControler() {
+		Routes.load(ResourceUtil.getResourceAsFile("routes/paths.xml"));
+		RoutingTestUtil.assertRecognizes("admin.nested.Foo#index",
+				"/admin/nested/foo");
+    }
 
 }

--- a/src/test/java/net/unit8/sastruts/testapp/action/admin/nested/FooAction.java
+++ b/src/test/java/net/unit8/sastruts/testapp/action/admin/nested/FooAction.java
@@ -1,0 +1,10 @@
+package net.unit8.sastruts.testapp.action.admin.nested;
+
+import org.seasar.struts.annotation.Execute;
+
+public class FooAction {
+	@Execute(validator = false)
+	public String index() {
+		return "index.jsp";
+	}
+}


### PR DESCRIPTION
HotDeploy/WarmDeploy時でかつActionのサブパッケージが2階層以上の場合、NoRouteExceptionが発生します。
元々は問題無かったのですが、4d70b258b8 の対応でClassControllerDetectorを修正した際、ドット -> スラッシュ変換がパッケージ部分に対して行われなくなっていました。
