### PR TITLE
AdvancedRoutingFilterでNPEが発生する問題を修正。

### DIFF
--- a/src/main/java/net/unit8/sastruts/AdvancedRoutingFilter.java
+++ b/src/main/java/net/unit8/sastruts/AdvancedRoutingFilter.java
@@ -192,7 +192,9 @@ public class AdvancedRoutingFilter implements Filter {
 					S2ExecuteConfig executeConfig;
 					if (StringUtil.equals(action, "index")) {
 						executeConfig = S2ExecuteConfigUtil.findExecuteConfig("/" + actionPath, req);
-						action = executeConfig.getMethod().getName();
+						if (executeConfig != null) {
+							action = executeConfig.getMethod().getName();
+						}
 					} else {
 						executeConfig = S2ExecuteConfigUtil.findExecuteConfig("/" + actionPath, action);
 					}


### PR DESCRIPTION
<match path=":controller/:action" />ルートでindexメソッドを持たないコントローラに対してindexメソッドを呼び出すとNPEが発生する。
ちなみにindexという名称以外の存在しないメソッドを呼び出した場合はNPEは発生しない。
indexメソッドが決め打ちで必ず存在する前提の処理が含まれていたため。
